### PR TITLE
fixes empty field test

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -101,7 +101,7 @@ var handleFormSubmit = function (event) {
     warranty: $warrantyExp
   };
 
-  if ((!newItem.item) || (!newItem.category) || (!newItem.location)) {
+  if ((!newItem.item) || (!newItem.CategoryId) || (!newItem.LocationId)) {
     alert("Item name, category, and location must be completed.");
     return;
   }


### PR DESCRIPTION
Because I forgot to rename a couple of things, the app always thought location and category Id fields were always empty.